### PR TITLE
feat: Telegram 转发支持可选 Topic ID（话题群组）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2224,6 +2224,7 @@ POST /api/cloudflare/channels
 | `smtp_use_ssl` | 是否启用 SSL |
 | `telegram_bot_token` | Telegram Bot Token |
 | `telegram_chat_id` | Telegram Chat ID |
+| `telegram_topic_id` | Telegram Topic ID（可选，话题群组的 message_thread_id） |
 | `normal_mail_local_retention_enabled` | 是否启用普通邮箱本地保留 |
 
 ### PUT `/api/settings`
@@ -2290,6 +2291,7 @@ POST /api/cloudflare/channels
 | `smtp_use_ssl` | bool | 是否启用 SSL |
 | `telegram_bot_token` | string | Telegram Bot Token |
 | `telegram_chat_id` | string | Telegram Chat ID |
+| `telegram_topic_id` | string | Telegram Topic ID（可选，话题群组的 message_thread_id，纯数字） |
 
 #### 请求示例
 
@@ -2562,7 +2564,8 @@ Telegram 测试：
   "config": {
     "telegram": {
       "bot_token": "123:abc",
-      "chat_id": "123456"
+      "chat_id": "123456",
+      "topic_id": "789"
     }
   }
 }

--- a/outlook_web/segments/01_bootstrap.py
+++ b/outlook_web/segments/01_bootstrap.py
@@ -2167,6 +2167,10 @@ def init_db():
     ''')
     cursor.execute('''
         INSERT OR IGNORE INTO settings (key, value)
+        VALUES ('telegram_topic_id', '')
+    ''')
+    cursor.execute('''
+        INSERT OR IGNORE INTO settings (key, value)
         VALUES ('telegram_proxy_url', '')
     ''')
     cursor.execute('''

--- a/outlook_web/segments/07_routes_oauth_settings_external.py
+++ b/outlook_web/segments/07_routes_oauth_settings_external.py
@@ -639,6 +639,7 @@ def api_get_settings():
     settings['smtp_use_ssl'] = get_setting('smtp_use_ssl', 'true')
     settings['telegram_bot_token'] = get_setting_decrypted('telegram_bot_token', '')
     settings['telegram_chat_id'] = get_setting('telegram_chat_id', '')
+    settings['telegram_topic_id'] = get_setting('telegram_topic_id', '')
     settings['telegram_proxy_url'] = get_setting('telegram_proxy_url', '')
     settings['wecom_webhook_url'] = get_setting_decrypted('wecom_webhook_url', '')
     settings['webdav_backup_enabled'] = get_setting('webdav_backup_enabled', 'false')
@@ -1124,6 +1125,12 @@ def api_update_settings():
             updated.append('Telegram Chat ID')
         else:
             errors.append('保存 Telegram Chat ID 失败')
+
+    if 'telegram_topic_id' in data:
+        if set_setting('telegram_topic_id', data['telegram_topic_id'].strip()):
+            updated.append('Telegram Topic ID')
+        else:
+            errors.append('保存 Telegram Topic ID 失败')
 
     if 'telegram_proxy_url' in data:
         if set_setting('telegram_proxy_url', data['telegram_proxy_url'].strip()):

--- a/outlook_web/segments/08_forwarding_scheduler_errors.py
+++ b/outlook_web/segments/08_forwarding_scheduler_errors.py
@@ -287,42 +287,46 @@ def send_forward_email_with_config(config: Dict[str, Any], subject: str, body_te
     return True
 
 
-def send_forward_telegram(text: str) -> bool:
-    bot_token = get_setting_decrypted('telegram_bot_token', '').strip()
-    chat_id = get_setting('telegram_chat_id', '').strip()
-    proxy_url = get_setting('telegram_proxy_url', '').strip()
+def _send_telegram_message(bot_token: str, chat_id: str, topic_id: str, proxy_url: str, text: str) -> bool:
     if not bot_token or not chat_id:
         return False
+    payload = {
+        'chat_id': chat_id,
+        'text': text[:4000],
+        'disable_web_page_preview': True,
+    }
+    if topic_id:
+        try:
+            payload['message_thread_id'] = int(topic_id)
+        except ValueError:
+            return False
     response = post_with_proxy_fallback(
         f'https://api.telegram.org/bot{bot_token}/sendMessage',
-        json={
-            'chat_id': chat_id,
-            'text': text[:4000],
-            'disable_web_page_preview': True,
-        },
+        json=payload,
         timeout=15,
         proxy_url=proxy_url,
     )
     return response.ok
+
+
+def send_forward_telegram(text: str) -> bool:
+    return _send_telegram_message(
+        get_setting_decrypted('telegram_bot_token', '').strip(),
+        get_setting('telegram_chat_id', '').strip(),
+        get_setting('telegram_topic_id', '').strip(),
+        get_setting('telegram_proxy_url', '').strip(),
+        text,
+    )
 
 
 def send_forward_telegram_with_config(config: Dict[str, Any], text: str) -> bool:
-    bot_token = str(config.get('bot_token', '') or '').strip()
-    chat_id = str(config.get('chat_id', '') or '').strip()
-    proxy_url = str(config.get('proxy_url', '') or '').strip()
-    if not bot_token or not chat_id:
-        return False
-    response = post_with_proxy_fallback(
-        f'https://api.telegram.org/bot{bot_token}/sendMessage',
-        json={
-            'chat_id': chat_id,
-            'text': text[:4000],
-            'disable_web_page_preview': True,
-        },
-        timeout=15,
-        proxy_url=proxy_url,
+    return _send_telegram_message(
+        str(config.get('bot_token', '') or '').strip(),
+        str(config.get('chat_id', '') or '').strip(),
+        str(config.get('topic_id', '') or '').strip(),
+        str(config.get('proxy_url', '') or '').strip(),
+        text,
     )
-    return response.ok
 
 
 def send_forward_wecom(text: str) -> bool:

--- a/static/js/index/07-settings.js
+++ b/static/js/index/07-settings.js
@@ -1816,6 +1816,7 @@
                     document.getElementById('settingsSmtpUseSsl').checked = String(data.settings.smtp_use_ssl) !== 'false';
                     document.getElementById('settingsTelegramBotToken').value = data.settings.telegram_bot_token || '';
                     document.getElementById('settingsTelegramChatId').value = data.settings.telegram_chat_id || '';
+                    document.getElementById('settingsTelegramTopicId').value = data.settings.telegram_topic_id || '';
                     document.getElementById('settingsTelegramProxyUrl').value = data.settings.telegram_proxy_url || '';
                     document.getElementById('settingsWecomWebhookUrl').value = data.settings.wecom_webhook_url || '';
                     document.getElementById('webdavBackupEnabled').checked = String(data.settings.webdav_backup_enabled) === 'true';
@@ -1908,6 +1909,7 @@
             const smtpUsername = document.getElementById('settingsSmtpUsername').value.trim();
             const telegramBotToken = document.getElementById('settingsTelegramBotToken').value.trim();
             const telegramChatId = document.getElementById('settingsTelegramChatId').value.trim();
+            const telegramTopicId = document.getElementById('settingsTelegramTopicId').value.trim();
             const telegramProxyUrl = document.getElementById('settingsTelegramProxyUrl').value.trim();
             const wecomWebhookUrl = document.getElementById('settingsWecomWebhookUrl').value.trim();
             const webdavBackupSettings = getWebdavBackupFormSettings();
@@ -1970,6 +1972,10 @@
                 showToast('启用 TG 转发时必须填写 Telegram Chat ID', 'error');
                 return;
             }
+            if (telegramTopicId && !/^\d+$/.test(telegramTopicId)) {
+                showToast('Telegram Topic ID 必须是纯数字', 'error');
+                return;
+            }
             if (forwardChannels.includes('wecom') && !wecomWebhookUrl) {
                 showToast('启用企业微信转发时必须填写 Webhook 地址', 'error');
                 return;
@@ -2029,6 +2035,7 @@
             settings.smtp_use_ssl = document.getElementById('settingsSmtpUseSsl').checked;
             settings.telegram_bot_token = telegramBotToken;
             settings.telegram_chat_id = telegramChatId;
+            settings.telegram_topic_id = telegramTopicId;
             settings.telegram_proxy_url = telegramProxyUrl;
             settings.wecom_webhook_url = wecomWebhookUrl;
 
@@ -2150,6 +2157,7 @@
                 telegram: {
                     bot_token: document.getElementById('settingsTelegramBotToken').value.trim(),
                     chat_id: document.getElementById('settingsTelegramChatId').value.trim(),
+                    topic_id: document.getElementById('settingsTelegramTopicId').value.trim(),
                     proxy_url: document.getElementById('settingsTelegramProxyUrl').value.trim(),
                 },
                 wecom: {
@@ -2191,6 +2199,10 @@
                 }
                 if (!draft.telegram.chat_id) {
                     showToast('请先填写 Telegram Chat ID', 'error');
+                    return;
+                }
+                if (draft.telegram.topic_id && !/^\d+$/.test(draft.telegram.topic_id)) {
+                    showToast('Telegram Topic ID 必须是纯数字', 'error');
                     return;
                 }
             } else if (channel === 'wecom') {

--- a/templates/partials/index/dialogs-management.html
+++ b/templates/partials/index/dialogs-management.html
@@ -541,6 +541,11 @@
                                         <label class="form-label">Telegram Chat ID</label>
                                         <input type="text" class="form-input" id="settingsTelegramChatId" placeholder="-1001234567890">
                                     </div>
+                                    <div class="form-group forward-field">
+                                        <label class="form-label">Telegram Topic ID</label>
+                                        <input type="text" class="form-input" id="settingsTelegramTopicId" placeholder="123">
+                                        <div class="form-hint">可选。群组开启话题（Topics）后，填写话题 ID 可将消息发送到指定话题。</div>
+                                    </div>
                                     <div class="form-group forward-field forward-field--full">
                                         <label class="form-label">Telegram 代理</label>
                                         <input type="text" class="form-input" id="settingsTelegramProxyUrl" placeholder="http://host:port、socks5://host:port 或 direct">


### PR DESCRIPTION
你好！首先感谢你开源并持续维护这个项目，功能很完善，用起来非常顺手。🙏

这个 PR 只添加了一个很小的功能：**Telegram 转发支持可选的 Topic ID**。

## 背景

Telegram 群组开启话题（Topics）功能后，Bot API 需要在 `sendMessage` 里带上 `message_thread_id` 才能把消息发到指定话题，否则消息只能落在 General。目前的转发配置只有 Bot Token 和 Chat ID，没法指定话题。

## 改动内容

完全沿用项目现有的模式，新增一个可选设置项 `telegram_topic_id`：

- **后端**：`init_db` 新增默认设置项；`GET/PUT /api/settings` 支持读写；发送时若填写了 Topic ID 则在请求体中附加 `message_thread_id`（整数），非数字返回失败
- **前端**：设置对话框在 Chat ID 下方新增 "Telegram Topic ID" 输入框（可选，带提示文字），保存和测试发送时做纯数字校验
- **文档**：`docs/api.md` 同步了字段说明

另外顺手把 `send_forward_telegram` 和 `send_forward_telegram_with_config` 中逐行重复的请求构建代码抽成了共用的 `_send_telegram_message()`，两个函数的签名和行为不变。如果你希望 PR 保持纯功能改动，我可以去掉这个小重构。

## 兼容性

**不填 Topic ID 时行为与原来完全一致**（请求体不带 `message_thread_id`），对现有用户零影响。

## 测试

- 本地实际运行验证：设置保存/回读、UI 显示、payload 构建（含 topic / 不含 topic / 非法值三种情况）均正常
- 现有测试套件 121 通过、1 跳过（`test_parse_email_datetime_accepts_parenthesized_timezone_name` 在 main 分支上同样失败，与本改动无关）

如有任何需要调整的地方（命名、交互、是否保留重构等），请随时告诉我，我会尽快跟进修改。再次感谢！