### PR TITLE
优化 Outlook邮箱授权页面：调整分页档位与表单布局

### DIFF
--- a/static/css/index/04-account-panel.css
+++ b/static/css/index/04-account-panel.css
@@ -317,7 +317,7 @@
             top: calc(100% + 8px);
             left: 0;
             z-index: 30;
-            width: min(320px, calc(100vw - 72px));
+            width: min(250px, calc(100vw - 72px));
             border: 1px solid #e5e7eb;
             border-radius: 16px;
             background: #ffffff;

--- a/static/js/index/12-outlook-upload-accounts.js
+++ b/static/js/index/12-outlook-upload-accounts.js
@@ -2,8 +2,8 @@
 
         // ==================== Outlook 上传账号 ====================
 
-        const UPLOAD_ACCOUNTS_PAGE_SIZE_DEFAULT = 200;
-        const UPLOAD_ACCOUNTS_PAGE_SIZE_OPTIONS = [100, 200, 500, 1000];
+        const UPLOAD_ACCOUNTS_PAGE_SIZE_DEFAULT = 20;
+        const UPLOAD_ACCOUNTS_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
         const UPLOAD_ACCOUNTS_PAGE_SIZE_STORAGE_KEY = 'outlook_upload_account_page_size';
         const UPLOAD_ACCOUNTS_AUTH_STATUS_OPTIONS = ['all', 'authorized', 'unauthorized'];
 

--- a/templates/partials/index/dialogs-management.html
+++ b/templates/partials/index/dialogs-management.html
@@ -1153,14 +1153,14 @@
 
     <!-- Outlook 上传账号模态框 -->
     <div class="modal" id="outlookUploadAccountsModal" onmousedown="if(event.target === this) hideOutlookUploadAccountsModal()">
-        <div class="modal-content" style="width: min(1500px, 96vw);">
+        <div class="modal-content" style="width: min(1740px, 96vw);">
             <div class="modal-header">
                 <h3>Outlook邮箱授权</h3>
                 <button class="modal-close" onclick="hideOutlookUploadAccountsModal()">&times;</button>
             </div>
             <div class="modal-body">
                 <div class="upload-accounts-guide">
-                    <details class="upload-accounts-guide__details" open>
+                    <details class="upload-accounts-guide__details">
                         <summary class="upload-accounts-guide__summary">
                             找不到批量导入？四种添加 / 授权方式说明（入口与区别）
                         </summary>
@@ -1302,11 +1302,11 @@
                                                 onchange="toggleSelectVisibleUploadAccounts(this.checked)">
                                         </th>
                                         <th style="width: 200px; min-width: 160px;">邮箱</th>
-                                        <th style="width: 80px; min-width: 70px;">密码</th>
+                                        <th style="width: 160px; min-width: 100px;">密码</th>
                                         <th style="width: 72px; min-width: 72px;">授权</th>
-                                        <th style="width: 120px; min-width: 100px;">标签</th>
-                                        <th style="width: 180px; min-width: 160px;">账号代理</th>
-                                        <th style="width: 100px; min-width: 80px;">备注</th>
+                                        <th style="width: 160px; min-width: 100px;">标签</th>
+                                        <th style="width: 160px; min-width: 160px;">账号代理</th>
+                                        <th style="width: 80px; min-width: 80px;">备注</th>
                                         <th style="width: 130px; min-width: 120px;">创建时间</th>
                                         <th style="width: 210px; min-width: 210px;">操作</th>
                                     </tr>
@@ -1323,10 +1323,10 @@
                             <div class="upload-accounts-pagination__controls">
                                 <select id="uploadAccountsPageSizeSelect" class="form-input upload-accounts-pagination__select"
                                     aria-label="每页数量" onchange="handleUploadAccountsPageSizeChange(this.value)">
+                                    <option value="10">每页 10</option>
+                                    <option value="20" selected>每页 20</option>
+                                    <option value="50">每页 50</option>
                                     <option value="100">每页 100</option>
-                                    <option value="200" selected>每页 200</option>
-                                    <option value="500">每页 500</option>
-                                    <option value="1000">每页 1000</option>
                                 </select>
                                 <button class="btn btn-secondary" type="button" id="uploadAccountsPrevBtn"
                                     onclick="changeUploadAccountsPage(-1)">上一页</button>
@@ -1704,7 +1704,7 @@
             border: 1px solid var(--skin-border, #e5e7eb);
             border-radius: 8px;
             background: var(--skin-surface, #ffffff);
-            overflow: hidden;
+            overflow: visible;
         }
         .upload-accounts-add-panel__header {
             display: flex;
@@ -1742,7 +1742,7 @@
         }
         .upload-accounts-add-form {
             display: grid;
-            grid-template-columns: 1fr 140px 1fr 1fr;
+            grid-template-columns: 180px 120px 180px 150px 120px 120px 250px auto;
             gap: 12px;
             align-items: end;
         }
@@ -1769,8 +1769,6 @@
             height: 36px;
         }
         .add-form-field--action {
-            grid-column: 1 / -1;
-            padding-top: 0;
             align-items: stretch;
         }
         .add-form-submit {


### PR DESCRIPTION
- 分页选项从 100/200/500/1000 改为 10/20/50/100，默认值改为 20
- 添加新账号表单改为单行布局（7列 + 按钮）
- 修复标签下拉弹窗被遮挡问题（overflow:visible）
- 标签弹窗宽度从 320px 调整为 250px