### PR TITLE
fix(export): 导出上传账号时解密 refresh_token

### DIFF
--- a/outlook_web/segments/07_routes_oauth_settings_external.py
+++ b/outlook_web/segments/07_routes_oauth_settings_external.py
@@ -1579,7 +1579,13 @@ def api_export_selected_upload_accounts():
         email = str(row['email'] or '')
         password = get_upload_account_plain_password(row, tolerate_decrypt_error=True)
         client_id = str(row['client_id'] or '')
-        refresh_token = str(row['refresh_token'] or '')
+        # refresh_token 在库中以 'enc:' 密文存储；导出必须解密成明文，否则外部
+        # 消费方拿到的是无法使用的密文。与 password 一致：解密失败时留空而不是
+        # 把密文泄漏到导出文件里。
+        try:
+            refresh_token = decrypt_data(str(row['refresh_token'] or ''))
+        except RuntimeError:
+            refresh_token = ''
         lines.append(f"{email}----{password}----{client_id}----{refresh_token}")
 
     content = '\n'.join(lines)

--- a/tests/test_project_runtime.py
+++ b/tests/test_project_runtime.py
@@ -1512,6 +1512,52 @@ class ProjectRuntimeTests(unittest.TestCase):
         self.assertIn('upload-b@example.com----pass-bbb--------', lines)
         self.assertNotIn('upload-c@example.com----pass-ccc', '\n'.join(lines))
 
+    def test_export_selected_upload_accounts_decrypts_refresh_token(self):
+        # Regression: the export must emit the plaintext refresh_token, never the
+        # stored 'enc:' ciphertext, or external consumers (e.g. the registration
+        # tool) send garbage to Microsoft and get AADSTS9002313 / invalid_grant.
+        with self.app.app_context():
+            db = web_outlook_app.get_db()
+            db.execute('DELETE FROM outlook_upload_accounts')
+            db.execute(
+                '''
+                INSERT INTO accounts (
+                    email, password, client_id, refresh_token,
+                    group_id, remark, status, account_type, provider,
+                    imap_host, imap_port, imap_password, forward_enabled
+                )
+                VALUES (?, '', ?, ?, 1, '', 'active', 'outlook', 'outlook', '', 993, '', 0)
+                ''',
+                (
+                    'upload-enc@example.com',
+                    'client-guid',
+                    web_outlook_app.encrypt_data('plain-refresh-token'),
+                ),
+            )
+            cursor = db.execute(
+                "INSERT INTO outlook_upload_accounts (email, password) VALUES (?, ?)",
+                ('upload-enc@example.com', web_outlook_app.encrypt_data('pass-enc')),
+            )
+            upload_id = cursor.lastrowid
+            web_outlook_app.set_setting('login_password', web_outlook_app.hash_password('export-pass4'))
+            db.commit()
+
+        verify_response = self.client.post('/api/export/verify', json={'password': 'export-pass4'})
+        verify_payload = verify_response.get_json()
+
+        response = self.client.post('/api/outlook-upload-accounts/export-selected', json={
+            'account_ids': [upload_id],
+            'verify_token': verify_payload['verify_token'],
+        })
+
+        self.assertEqual(response.status_code, 200)
+        content = response.get_data(as_text=True)
+        self.assertIn(
+            'upload-enc@example.com----pass-enc----client-guid----plain-refresh-token',
+            content,
+        )
+        self.assertNotIn('enc:', content)
+
     def test_export_selected_upload_accounts_empty_ids_returns_400(self):
         with self.app.app_context():
             web_outlook_app.set_setting('login_password', web_outlook_app.hash_password('export-pass3'))


### PR DESCRIPTION
「导出选中的 Outlook 上传账号」此前把库中 refresh_token 的 'enc:' 密文 原样写入导出文件（password 已解密，refresh_token 漏了）。外部消费方拿到
密文发给微软会得到 AADSTS9002313 / invalid_grant。

改为与 password 一致先 decrypt_data 解密；解密失败留空而非泄漏密文。
新增回归测试覆盖加密 refresh_token 的导出。